### PR TITLE
feat: add gradient hero intro and smoother slider

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
     .hero{position:relative;overflow:hidden}
     .hero-slider{position:absolute;top:0;left:0;width:100%;height:100%;z-index:-2;overflow:hidden}
     .hero::before{content:'';position:absolute;inset:0;background:rgba(0,0,0,.55);z-index:-1}
-    .hero-slide{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;opacity:0;transition:opacity 1s ease-in-out}
+    .hero-slide{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;opacity:0;transition:opacity 4s ease-in-out}
     .hero-slide.active{opacity:1}
 
     .hero-benefits{list-style:none;padding:0;margin:1rem auto;display:flex;flex-wrap:wrap;justify-content:center;gap:1.5rem;max-width:800px;font-size:1rem}
@@ -120,7 +120,7 @@
       </div>
       <div class="container">
         <div class="hero-content">
-          <h1>PACK. OPTIMIZE. DEPLOY. SCALE UP.</h1>
+          <h1>Streamline. Automate. Elevate.</h1>
           <p class="subtitle">Your one-man army for scalable tech systems.</p>
           <ul class="hero-benefits">
             <li><i class="fas fa-rocket" aria-hidden="true"></i> Rapid deployment &amp; scalability</li>
@@ -303,9 +303,17 @@
   <!-- Hero Slider -->
   <script>
     document.addEventListener('DOMContentLoaded',function(){
-      const heroSlides=document.querySelectorAll('.hero-slide');let i=0;
+      const heroSlides=document.querySelectorAll('.hero-slide');
+      let i=0;
       function show(n){heroSlides.forEach((s,idx)=>{s.classList.toggle('active',idx===n);});}
-      if(heroSlides.length){show(i);setInterval(()=>{i=(i+1)%heroSlides.length;show(i);},7000);}
+      if(heroSlides.length){
+        show(i);
+        setTimeout(()=>{
+          i=(i+1)%heroSlides.length;
+          show(i);
+          setInterval(()=>{i=(i+1)%heroSlides.length;show(i);},8000);
+        },5000);
+      }
     });
   </script>
 

--- a/main.css
+++ b/main.css
@@ -97,6 +97,20 @@ header.site-header {
 .hero-content h1 {
   font-size: 2.5rem;
   margin-bottom: 1rem;
+  background: linear-gradient(90deg, #29b3f0, #d946ef, #f97316, #29b3f0);
+  background-size: 300% 100%;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  animation: gradientShift 5s linear infinite, fadeOut 1s ease forwards 5s;
+}
+
+@keyframes gradientShift {
+  0% { background-position: 0% 50%; }
+  100% { background-position: 100% 50%; }
+}
+
+@keyframes fadeOut {
+  to { opacity: 0; }
 }
 
 .hero-content .subtitle {
@@ -349,12 +363,6 @@ footer.footer a {
   border-bottom: 1px solid var(--border-color);
 }
 
-[data-theme="light"] .hero::before {
-  /* lighter overlay for hero so text still readable on bright images */
-  background: rgba(255, 255, 255, 0.35);
-}
-
-[data-theme="light"] .hero-content h1,
 [data-theme="light"] .hero-content p {
   color: var(--text-color);
   text-shadow: none;


### PR DESCRIPTION
## Summary
- add gradient "Streamline. Automate. Elevate." intro that fades after 5s
- start hero slider after intro with 4s cross-fade transitions
- keep hero overlay dark across themes

## Testing
- `npx htmlhint index.html`
- `npx stylelint main.css` *(fails: No configuration provided)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c4f716c0832090f2c11abc6a15a7