### PR TITLE
fix dark mode service card background

### DIFF
--- a/main.css
+++ b/main.css
@@ -297,17 +297,14 @@ img {
   text-align: center;
   position: relative;
   border: 2px solid transparent;
-  background-image: linear-gradient(var(--card-bg), var(--card-bg)),
-    linear-gradient(90deg, #29b3f0, #d946ef);
-  background-origin: border-box;
-  background-clip: padding-box, border-box;
+  background-color: var(--card-bg);
+  border-image: linear-gradient(90deg, #29b3f0, #d946ef) 1;
   transition: transform 0.3s ease, background-color 0.3s ease;
 }
 
 .service-card:hover {
   transform: translateY(-6px);
-  background-image: linear-gradient(var(--card-bg-hover), var(--card-bg-hover)),
-    linear-gradient(90deg, #29b3f0, #d946ef);
+  background-color: var(--card-bg-hover);
 }
 
 .service-card img,


### PR DESCRIPTION
## Summary
- ensure service cards show gradient only on their borders in dark mode

## Testing
- `npx --yes htmlhint index.html`
- `npx --yes stylelint main.css` *(fails: ConfigurationError: No configuration provided)*

------
https://chatgpt.com/codex/tasks/task_e_68b9261bf12483208187a95b756632dc